### PR TITLE
Specify which version includes the fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CVE-2019-9673: Freenet content filter vulnerability
 
-**NOTE: I have fully disclosed this bug to the Freenet team and worked with them to verify their patch. The patch is now deployed in the latest version of Freenet.**
+**NOTE: I have fully disclosed this bug to the Freenet team and worked with them to verify their patch. The patch was merged in build 1484 of Freenet.**
 
 I've recently found a security vulnerability in Freenet that may allow an attacker to 
 de-anonymize a target or send malicious documents through Freenet. 


### PR DESCRIPTION
See https://freenetproject.org/freenet-build-1484-released.html

> Thesnark discovered a way to circumvent the content filter, which was fixed by operhiem1. This bug could have resulted in handing an insecure file to an external (and potentially vulnerable) program without showing a warning to the user. Please update ASAP to avoid that. See CVE-2019-9673 for details.